### PR TITLE
Discarding the master-slave language

### DIFF
--- a/a.1.1.py
+++ b/a.1.1.py
@@ -8,7 +8,7 @@
 #
 # Changes Logs:
 # [2013-04-20] By A-Lang
-#              Replaced the lircrc with the mplayer's slave mode
+#              Replaced the lircrc with the mplayer's subordinate mode
 #              Added the audio volume control
 #              Added the Mute,Power keys function
 #
@@ -24,9 +24,9 @@ def PlayRadio(station):
     print stationlist[station]
     os.system("killall " + "mplayer");
     if 'pls' in stationlist[station] or 'asx' in stationlist[station]:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
     else:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 " + stationlist[station].rstrip("\n") + " < /dev/null &"
     player = subprocess.Popen(Play_station.split(" "), stdin=PIPE, stdout=PIPE, stderr=PIPE)
     return player
 

--- a/a.1.py
+++ b/a.1.py
@@ -7,7 +7,7 @@
 #
 # Changes Logs:
 # [2013-04-20] By A-Lang
-#              Replaced the lircrc with the mplayer's slave mode
+#              Replaced the lircrc with the mplayer's subordinate mode
 #              Added the audio volume control
 #              Added the Mute,Power keys function
 #
@@ -33,7 +33,7 @@ def PlayRadio(station):
        os.system("killall " + "mplayer");
        current_station = station
        print current_station
-       Play_station = "mplayer -ao oss -slave -quiet -cache 256 " + stationlist[current_station].rstrip("\n") + " < /dev/null &"
+       Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 " + stationlist[current_station].rstrip("\n") + " < /dev/null &"
        player = subprocess.Popen(Play_station.split(" "), stdin=PIPE)
 
 fd = open ("/root/NextRadio/radio.pls","r")

--- a/a.py
+++ b/a.py
@@ -8,7 +8,7 @@
 #
 # Changes Logs:
 # [2013-04-20] By A-Lang
-#              Replaced the lircrc with the mplayer's slave mode
+#              Replaced the lircrc with the mplayer's subordinate mode
 #              Added the audio volume control
 #              Added the Mute,Power keys function
 #
@@ -24,9 +24,9 @@ def PlayRadio(station):
     print station, stationlist[station]
     os.system("killall " + "mplayer");
     if 'pls' in stationlist[station] or 'asx' in stationlist[station]:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
     else:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 " + stationlist[station].rstrip("\n") + " < /dev/null &"
     player = subprocess.Popen(Play_station.split(" "), stdin=PIPE, stdout=PIPE, stderr=PIPE)
     return player
 

--- a/aladdin.py
+++ b/aladdin.py
@@ -9,7 +9,7 @@
 #
 # Changes Logs:
 # [2013-04-20] By A-Lang
-#              Replaced the lircrc with the mplayer's slave mode
+#              Replaced the lircrc with the mplayer's subordinate mode
 #              Added the audio volume control
 #              Added the Mute,Power keys function
 #
@@ -39,9 +39,9 @@ def PlayRadio(station):
     #Say_station(station)
     time.sleep(1)
     if 'pls' in stationlist[station] or 'asx' in stationlist[station]:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 " + "-loop 0 " + "-cache-min 10" + prompt + " -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 " + "-loop 0 " + "-cache-min 10" + prompt + " -playlist " + stationlist[station].rstrip("\n") + " < /dev/null &"
     else:
-        Play_station = "mplayer -ao oss -slave -quiet -cache 256 " + "-loop 0 " + "-cache-min 10" + prompt + " " + stationlist[station].rstrip("\n") + " < /dev/null &"
+        Play_station = "mplayer -ao oss -subordinate -quiet -cache 256 " + "-loop 0 " + "-cache-min 10" + prompt + " " + stationlist[station].rstrip("\n") + " < /dev/null &"
     print Play_station
     player = subprocess.Popen(Play_station.split(" "), stdin=PIPE, stdout=PIPE, stderr=PIPE)
     return player


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.